### PR TITLE
Add in now_and_every

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ every_five_seconds = timers.every(5) { puts "Another 5 seconds" }
 loop { timers.wait }
 ```
 
+You also schedule a block to run immediately, and then periodically, with `Timers::Group#every_with_now`:
+```ruby
+every_with_now_five_seconds = timers.every_with_now(5) { puts "Now and another 5 seconds" } # The block runs immediately and then periodically
+
+loop { timer.wait }
+```
+
 If you'd like another method to do the waiting for you, e.g. `Kernel.select`,
 you can use `Timers::Group#wait_interval` to obtain the amount of time to wait. When
 a timeout is encountered, you can fire all pending timers with `Timers::Group#fire`:

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ every_five_seconds = timers.every(5) { puts "Another 5 seconds" }
 loop { timers.wait }
 ```
 
-You also schedule a block to run immediately, and then periodically, with `Timers::Group#every_with_now`:
+You also schedule a block to run immediately, and then periodically, with `Timers::Group#now_and_every`:
 ```ruby
-every_with_now_and_five_seconds = timers.every_with_now(5) { puts "Now and another 5 seconds" }
+now_and_every_five_seconds = timers.now_and_every(5) { puts "Now and another 5 seconds" }
 
 loop { timer.wait }
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ loop { timers.wait }
 
 You also schedule a block to run immediately, and then periodically, with `Timers::Group#every_with_now`:
 ```ruby
-every_with_now_five_seconds = timers.every_with_now(5) { puts "Now and another 5 seconds" } # The block runs immediately and then periodically
+every_with_now_and_five_seconds = timers.every_with_now(5) { puts "Now and another 5 seconds" }
 
 loop { timer.wait }
 ```

--- a/lib/timers/group.rb
+++ b/lib/timers/group.rb
@@ -46,7 +46,7 @@ module Timers
 
     # Call the given block immediately, and then periodically at the given interval. The first
     # argument will be the time at which the group was asked to fire timers for.
-    def every_with_now(interval, recur = true, &block)
+    def now_and_every(interval, recur = true, &block)
       block.call
       every(interval, recur, &block)
     end

--- a/lib/timers/group.rb
+++ b/lib/timers/group.rb
@@ -44,6 +44,13 @@ module Timers
       Timer.new(self, interval, recur, &block)
     end
 
+    # Call the given block immediately, and then periodically at the given interval. The first
+    # argument will be the time at which the group was asked to fire timers for.
+    def every_with_now(interval, recur = true, &block)
+      block.call
+      every(interval, recur, &block)
+    end
+
     # Wait for the next timer and fire it. Can take a block, which should behave
     # like sleep(n), except that n may be nil (sleep forever) or a negative
     # number (fire immediately after return).

--- a/spec/every_spec.rb
+++ b/spec/every_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Timers::Group do
 
     subject.every(0.7) { result << :a }
     subject.every(2.3) { result << :b }
-    subject.every_with_now(1.3) { result << :c }
-    subject.every_with_now(2.4) { result << :d }
+    subject.now_and_every(1.3) { result << :c }
+    subject.now_and_every(2.4) { result << :d }
 
     Timers::Wait.for(2.5) do |remaining|
       subject.wait if subject.wait_interval < remaining

--- a/spec/every_spec.rb
+++ b/spec/every_spec.rb
@@ -16,4 +16,19 @@ RSpec.describe Timers::Group do
 
     expect(result).to be == [:a, :c, :a, :a, :b, :d]
   end
+
+  it "should fire immediately and then several times later" do
+    result = []
+
+    subject.every(0.7) { result << :a }
+    subject.every(2.3) { result << :b }
+    subject.every_with_now(1.3) { result << :c }
+    subject.every_with_now(2.4) { result << :d }
+
+    Timers::Wait.for(2.5) do |remaining|
+      subject.wait if subject.wait_interval < remaining
+    end
+
+    expect(result).to be == [:c, :d, :a, :c, :a, :a, :b, :d]
+  end
 end


### PR DESCRIPTION
`now_and_every` works as `every`, except the first run is called immediately.

I have faced a situation whereby I needed to schedule the task to run `every(5.minutes)`, but I didn't want to wait that long for the first run to be called. Of course, I could've done:

1) have the block defined as a method
2) call it immediately
3) put it in `every`

But this is cumbersome. Therefore, `now_and_every` is a convenience to support this case.

NOTE: refactored from `every_with_now`