### PR TITLE
Travis fixups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
+language: ruby
+sudo: false
+
+bundler_args: --without development doc
+
 rvm:
   - 2.0.0
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
-  - ruby-head
-  - jruby
-  - jruby-head
-  - rbx-2
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - jruby-9.1.6.0
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - rvm: ruby-head
-    - rvm: jruby-head
-    - rvm: rbx-2
 
 branches:
   only:


### PR DESCRIPTION
- Use JRuby 9000
- Use containerized build system (sudo: false)
- Drop *-head rubies and rbx-2
- Update all Rubies to the latest versions